### PR TITLE
fix: Allow the symfony/runtime plugin so vendor/autoload_runtime.php is generated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
       "drupal/core-composer-scaffold": true,
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "mglaman/composer-drupal-lenient": true,
-      "symfony/runtime": false
+      "symfony/runtime": true
     }
   },
   "extra": {


### PR DESCRIPTION
### Problem

`composer.json` set `config.allow-plugins.symfony/runtime: false`. The `symfony/runtime` package is installed, but with its Composer plugin disallowed, `vendor/autoload_runtime.php` is never generated. The scaffolded `web/autoload_runtime.php` unconditionally `require`s that file, so **every request fatals**:

```
Failed opening required '.../vendor/autoload_runtime.php'
```

This blocks the Drupal install wizard from loading — a release-blocker for the webship_project 11.0.0 release. CI masks the bug because `.gitlab-ci.yml` writes a stub of `vendor/autoload_runtime.php`.

### Fix

One line in `composer.json`: set `config.allow-plugins.symfony/runtime` from `false` to `true`, so the plugin runs during `composer install` and generates `vendor/autoload_runtime.php`. Nothing else changed.

### Validation

Proved the fix by setting the flag to `true` and running a plain `composer install` — `vendor/autoload_runtime.php` is generated — then completing **5/5 browser install rounds** (core 11.4.4, profile `webship`, 17 web* modules). No regression observed.

### Tracking issue

Tracking issue to be linked once the webship_project issue queue is enabled. (Issues are currently disabled on this project, so this is a same-project feature-branch MR rather than an issue-fork MR.)

### Checkpoints
- [ ] File an issue
- [x] Fix bugs in code
- [x] Testing to ensure no regression
- [ ] Automated unit testing coverage
- [ ] Automated functional testing coverage
- [ ] UX/UI designer responsibilities
- [ ] Readability
- [ ] Accessibility
- [ ] Performance
- [ ] Security
- [ ] Documentation
- [ ] Reviewed by human
- [ ] Code review by maintainers
- [ ] Full testing and approval
- [ ] Credit contributors
- [ ] Review with the product owner
- [ ] Release Notes
- [ ] Release